### PR TITLE
Handle empty override_policy_documents field

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 }
 
 data "aws_iam_policy_document" "bucket" {
-  override_policy_documents = [var.bucket_policy]
+  override_policy_documents = compact([var.bucket_policy])
 
   statement {
     sid       = "AllowManagement"


### PR DESCRIPTION
Right now when this field is empty, it is passed in as `[null]`, which causes this resource to break.

By running `compact()` we get the array as intended: `[]`.