### PR TITLE
Fix null IAM policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 }
 
 data "aws_iam_policy_document" "bucket" {
-  override_policy_documents = [var.bucket_policy]
+  override_policy_documents = compact([var.bucket_policy])
 
   statement {
     sid       = "AllowManagement"


### PR DESCRIPTION
If the bucket policy was empty, a null override would be provided. This causes an error in newer versions of the AWS provider.
