### PR TITLE
Separate read/write permissions in bucket policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | Override the resource policy on the bucket | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the s3 bucket | `string` | n/a | yes |
+| <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principal allowed to read from the bucket (default: current account) | `list(string)` | `[]` | no |
+| <a name="input_read_tags"></a> [read\_tags](#input\_read\_tags) | Tags required on principals reading to the bucket | `map(string)` | `{}` | no |
+| <a name="input_readwrite_principals"></a> [readwrite\_principals](#input\_readwrite\_principals) | Principal allowed to read and write to the bucket (default: current account) | `list(string)` | `[]` | no |
+| <a name="input_readwrite_tags"></a> [readwrite\_tags](#input\_readwrite\_tags) | Tags required on principals writing to the bucket | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
-| <a name="input_trust_principal"></a> [trust\_principal](#input\_trust\_principal) | Principal allowed to access the secret (default: current account) | `string` | `null` | no |
-| <a name="input_trust_tags"></a> [trust\_tags](#input\_trust\_tags) | Tags required on principals accessing the secret | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ lint: .lint
 	@touch .lintinit
 
 README.md: $(MODULEFILES)
-	terraform-docs markdown table . --output-file README.md
+	terraform-docs markdown table . --output-file README.md --lockfile=false
 
 .fmt: $(MODULEFILES)
 	terraform fmt -check

--- a/variables.tf
+++ b/variables.tf
@@ -15,14 +15,26 @@ variable "tags" {
   default     = {}
 }
 
-variable "trust_principal" {
-  description = "Principal allowed to access the secret (default: current account)"
-  type        = string
-  default     = null
+variable "read_principals" {
+  description = "Principal allowed to read from the bucket (default: current account)"
+  type        = list(string)
+  default     = []
 }
 
-variable "trust_tags" {
-  description = "Tags required on principals accessing the secret"
+variable "read_tags" {
+  description = "Tags required on principals reading to the bucket"
+  type        = map(string)
+  default     = {}
+}
+
+variable "readwrite_principals" {
+  description = "Principal allowed to read and write to the bucket (default: current account)"
+  type        = list(string)
+  default     = []
+}
+
+variable "readwrite_tags" {
+  description = "Tags required on principals writing to the bucket"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
The bucket currently only supports a "trust principal" which can both read from and write to the bucket. This introduces separate read and write principals so that read-only access can be granted.
